### PR TITLE
Fixes https://github.com/40fingers/StyleHelper-Sko/issues/5

### DIFF
--- a/StyleHelper.ascx.vb
+++ b/StyleHelper.ascx.vb
@@ -925,6 +925,21 @@ Namespace FortyFingers.Dnn.SkinObjects
                 Return _sIfCulture
             End Get
         End Property
+		
+		
+		 Private _strIfToken As String = String.Empty
+        ''' <summary>
+        ''' If this is empty or all Token passed return more than an empty String this returns True 
+        ''' </summary>
+        ''' <returns></returns>
+        Public Property IfToken() As String
+            Get
+                Return _strIfToken
+            End Get
+            Set(ByVal value As String)
+                _strIfToken = value
+            End Set
+        End Property
 
 
 
@@ -2303,7 +2318,8 @@ Namespace FortyFingers.Dnn.SkinObjects
             CheckTextDir(IfTextDir) AndAlso _
             CheckMobile() AndAlso _
             CheckNoCookies(IfNoCookie) AndAlso _
-            CheckCookies(IfCookie)
+            CheckCookies(IfCookie) AndAlso _
+			CheckTokens(IfToken)
 
         End Function
 
@@ -3110,6 +3126,30 @@ Namespace FortyFingers.Dnn.SkinObjects
 
                 Next
                 Return (bOut)
+            End If
+
+        End Function
+		
+		''' <summary>
+        ''' Test to see if the parsed token striong returns anything.
+        ''' If it does return True
+        ''' If it doesn't return False
+        ''' </summary>
+        ''' <param name="sTokens"></param>
+        ''' <returns></returns>
+        Protected Function CheckTokens(sTokens As String) As Boolean
+
+            If sTokens = String.Empty Then
+                Return True
+            Else
+
+
+                If ProcessTokens(sTokens).Trim = String.Empty Then
+                    Return False
+                Else
+                    Return True
+                End If
+
             End If
 
         End Function


### PR DESCRIPTION
### Conditional Content using Style Helper based on Tokens:

 **"IfToken" will be true if it returns anything but an empty String**
	
Examples: 
<fortyfingers:STYLEHELPER ID="SH0" IfToken="[Page:Title]" Content="Page Title: [Page:Title]" ContentFalse="No Page Title" runat="server" />
<fortyfingers:STYLEHELPER ID="SH1" IfToken="[Page:IconFile]" Content="Page Icon: [Page:Icon]" ContentFalse="No Page Icon" runat="server" />
<fortyfingers:STYLEHELPER ID="SH2" IfToken="[Page:IconFileLarge]" Content="Page Large Icon: [Page:IconLarge]" ContentFalse="No Page Large Icon" runat="server" />

Fixes #5 